### PR TITLE
Add Windows Support

### DIFF
--- a/src/extension.coffee
+++ b/src/extension.coffee
@@ -10,7 +10,7 @@ EXT_ID = 'git-log--graph'
 
 git = (###* @type string ### args) =>
 	{ stdout, stderr } = await exec 'git ' + args,
-		cwd: vscode.workspace.getConfiguration(EXT_ID).get('folder') or vscode.workspace.workspaceFolders?[0].uri.path
+		cwd: vscode.workspace.getConfiguration(EXT_ID).get('folder') or vscode.workspace.workspaceFolders?[0].uri.fsPath
 		# 35 MB. For scale, Linux kernel git graph (1 mio commits) in extension format is 538 MB or 7.4 MB for the first 15k commits
 		maxBuffer: 1024 * 1024 * 35
 	stdout

--- a/src/extension.coffee
+++ b/src/extension.coffee
@@ -18,7 +18,7 @@ git = (###* @type string ### args) =>
 module.exports.activate = (###* @type vscode.ExtensionContext ### context) =>
 	context.subscriptions.push vscode.workspace.registerTextDocumentContentProvider 'git-show',
 		provideTextDocumentContent: (uri) ->
-			(try await git "show '#{uri.path}'") or ''
+			(try await git "show \"#{uri.path}\"") or ''
 
 	context.subscriptions.push vscode.commands.registerCommand 'git-log--graph.start', =>
 		panel = vscode.window.createWebviewPanel(EXT_NAME, EXT_NAME, vscode.window.activeTextEditor?.viewColumn or 1, { enableScripts: true, retainContextWhenHidden: true, localResourceRoots: [ vscode.Uri.joinPath(context.extensionUri, 'web-dist'), vscode.Uri.joinPath(context.extensionUri, 'media') ] })

--- a/web/src/views/MainView.coffee
+++ b/web/src/views/MainView.coffee
@@ -88,7 +88,7 @@ export default
 			sep = '^%^%^%^%^'
 			log_args = log_args.replace(" --pretty=VSCode", " --pretty=format:\"#{sep}%h#{sep}%an#{sep}%ae#{sep}%at#{sep}%D#{sep}%s\"")
 			stash_refs = try await git 'reflog show --format="%h" stash' catch then ""
-			log_args = log_args.replace("stash_refs", stash_refs)
+			log_args = log_args.replace("stash_refs", stash_refs.replaceAll('\n', ' '))
 			# errors will be handled by GitInput
 			[ log_data, stash_data ] = await Promise.all [
 				git log_args

--- a/web/src/views/SelectedCommit.coffee
+++ b/web/src/views/SelectedCommit.coffee
@@ -28,16 +28,16 @@ export default defineComponent
 			get_files_command =
 				if stash.value
 					# so we can see untracked as well
-					"stash show --include-untracked --numstat --format='' #{props.commit.hash}"
+					"stash show --include-untracked --numstat --format=\"\" #{props.commit.hash}"
 				else
-					"diff --numstat --format='' #{props.commit.hash} #{props.commit.hash}~1"
+					"diff --numstat --format=\"\" #{props.commit.hash} #{props.commit.hash}~1"
 			changed_files.value = (try await git get_files_command)
 				?.split('\n').map((l) =>
 					split = l.split('\t')
 					path: split[2]
 					insertions: Number split[1]
 					deletions: Number split[0]) or []
-			body.value = await git "show -s --format='%b' #{props.commit.hash}"
+			body.value = await git "show -s --format=\"%b\" #{props.commit.hash}"
 		
 		show_diff = (###* @type string ### filepath) =>
 			open_diff props.commit.hash, filepath


### PR DESCRIPTION
Some fixes to errors that occur on Windows:

- Use uri.fsPath instead of uri.path to get the working directory in OS-specific format
- Escape quote characters inside command strings
- Use magic text (similar to 'VSCode' pretty format) to represent stash refs so they can be evaluated in a separate step - Windows Command Prompt does not understand $(git ...) expressions and has no equivalent.