### PR TITLE
Invert and hue-rotate filters on light theme

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -43,7 +43,7 @@ body {
 
 	&.vscode-light {
 		background-color: var(--vscode-editor-background);
-		filter: invert( 1 ) hue-rotate( 180deg );
+		filter: invert(1) hue-rotate(180deg);
 	}
 }
 

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -40,6 +40,11 @@ body {
 	font-family: var(--vscode-font-family);
 	// background-color: var(--vscode-editor-background); TODO:
 	background-color: #161616;
+
+	&.vscode-light {
+		background-color: var(--vscode-editor-background);
+		filter: invert( 1 ) hue-rotate( 180deg );
+	}
 }
 
 ol, ul, *[role=list] {


### PR DESCRIPTION
Applies invert and hue-rotate filters on the light theme.
I have never heard Stylus, so the code could be bad.

Inspired by [the MediaWiki DarkMode](https://github.com/wikimedia/mediawiki-extensions-DarkMode/blob/0a65e9911c80b213add39cf1e1b093baa8b08fbd/resources/ext.DarkMode.less#LL68C4-L68C45).

Closes #13.