### PR TITLE
Add buttons in the changed files section

### DIFF
--- a/src/extension.coffee
+++ b/src/extension.coffee
@@ -1,4 +1,5 @@
 vscode = require 'vscode'
+path = require 'path'
 
 { get_git } = require './git'
 
@@ -76,6 +77,13 @@ module.exports.activate = (###* @type vscode.ExtensionContext ### context) =>
 							uri_1 = vscode.Uri.parse "#{EXT_ID}-git-show:#{d.hashes[0]}:#{d.filename}"
 							uri_2 = vscode.Uri.parse "#{EXT_ID}-git-show:#{d.hashes[1]}:#{d.filename}"
 							vscode.commands.executeCommand 'vscode.diff', uri_1, uri_2, "#{d.filename} #{d.hashes[0]} vs. #{d.hashes[1]}"
+						when 'view-rev' then h =>
+							uri = vscode.Uri.parse "#{EXT_ID}-git-show:#{d.hash}:#{d.filename}"
+							vscode.commands.executeCommand 'vscode.open', uri
+						when 'open-file' then h =>
+							workspace = vscode.workspace.workspaceFolders[git.get_selected_repo_index()].uri.fsPath
+							uri = vscode.Uri.file path.join workspace, d.filename
+							vscode.commands.executeCommand 'vscode.open', uri
 						when 'get-config' then h =>
 							vscode.workspace.getConfiguration(EXT_ID).get d
 						when 'get-repo-names' then h =>

--- a/web/src/views/CommitDetails.coffee
+++ b/web/src/views/CommitDetails.coffee
@@ -64,7 +64,13 @@ export default defineComponent
 			exchange_message 'open-diff',
 				hashes: [props.commit.hash+'~1', props.commit.hash]
 				filename: filepath
-		
+		view_rev = (###* @type string ### filepath) =>
+			exchange_message 'view-rev',
+				hash: props.commit.hash
+				filename: filepath
+		open_file = (###* @type string ### filepath) =>
+			exchange_message 'open-file',
+				filename: filepath
 		_commit_actions = computed =>
 			commit_actions(props.commit.hash).value
 		_stash_actions = computed =>
@@ -81,6 +87,8 @@ export default defineComponent
 			stash
 			changed_files
 			show_diff
+			view_rev
+			open_file
 			body
 			commit_actions: _commit_actions
 			branch_actions: _branch_actions

--- a/web/src/views/CommitDetails.vue
+++ b/web/src/views/CommitDetails.vue
@@ -34,13 +34,19 @@ div
 
 	h3 Changed files:
 	ul.changed-files
-		li v-for="file of changed_files"
-			button.change.row.center.gap-5 @click="show_diff(file.path)"
+		li.row v-for="file of changed_files"
+			button.change.center.gap-5 @click="show_diff(file.path)"
 				.count {{ (file.insertions + file.deletions) || 0 }}
 				progress.diff :value="(file.insertions / (file.insertions + file.deletions)) || 0" title="Ratio insertions / deletions"
 				.path.flex-1.row.gap-10.align-center
 					.filename {{ file.filename }}
 					.dir {{ file.dir }}
+			div.btns
+				button.view-rev @click="view_rev(file.path)" title="View File at this Revision"
+					i.codicon.codicon-git-commit
+				button.open-file @click="open_file(file.path)" title="Open file"
+					i.codicon.codicon-go-to-file
+
 </template>
 
 <script lang="coffee" src="./CommitDetails.coffee"></script>
@@ -54,17 +60,25 @@ h2.summary
 .changed-files
 	padding 0
 	overflow auto
-	.change
-		font-family monospace
-		font-size 90%
-		> .count
-			text-align right
-			width 2rem
-		> .path
-			white-space pre
-			> .dir
-				color #aaa
-				font-size 90%
+	.row
+		.change
+			font-family monospace
+			font-size 90%
+			> .count
+				text-align right
+				width 2rem
+			> .path
+				white-space pre
+				> .dir
+					color #aaa
+		.btns
+			margin-left 0.5rem
+			opacity 0
+			button
+				.open-file, .view-rev
+					font-size 90%
+		&:hover .btns
+				opacity 1
 .body
 	white-space pre-wrap
 	word-break break-word


### PR DESCRIPTION
This is another features vscode-git-graph provides.

## Image
![image](https://github.com/phil294/git-log--graph/assets/28209361/e19047b5-71ed-4fe1-bff8-3cb9ac18c1ba)

## Video
[Screencast from 2023-05-24 01-25-27.webm](https://github.com/phil294/git-log--graph/assets/28209361/0b2c3699-716b-4553-a40c-ba63a67666e4)

A known issue: vscode-git-graph only shows the buttons when the file exists. However, in this PR, deleted file will result in 'File not found' window.